### PR TITLE
Alert Data Source Cache Miss Number Growing Over Time

### DIFF
--- a/alerts.yml
+++ b/alerts.yml
@@ -1,0 +1,22 @@
+groups:
+  - name: sparkd
+    rules:
+      # Check if a datasource is missing caches for more than 2 days
+      - alert: DatasourceMissingCaches
+        expr: >
+          (sparkd_bridge_datasource_cache_misses{environment=~"live"} 
+          UNLESS 
+          last_over_time(
+            (
+              rate(
+                sparkd_bridge_datasource_cache_misses{environment=~"live"}[3m]
+              )==0
+            )[2d:3m]
+          ))>0
+        for: 5m
+        labels:
+          team: customer-success
+        annotations:
+          summary: >
+            Data source {{ $labels.name }} of customer {{ $labels.customer }} and appliance {{ $labels.appliance }}
+            has not been reading out data for at least two days.

--- a/drone.yml
+++ b/drone.yml
@@ -1,0 +1,81 @@
+python_image: &python_image
+  image: python:3.11-slim
+
+docker_image: &docker_image
+  image: docker:latest
+  volumes:
+    - name: dockersock
+      path: /var/run
+
+depend_on_clone: &depend_on_clone
+    depends_on:
+    - clone
+
+pip_cache: &pip_cache
+  volumes:
+    - name: pip_cache
+      path: /root/.cache/pip
+
+run_on_prs_only_condition: &run_on_prs_only_condition
+  when:
+    event:
+     - pull_request
+
+production_condition: &production_condition
+  when:
+    branch:
+      - master
+    event:
+      - push
+
+deployment_image_config: &deployment_image_config
+  pull: always
+  image: docker.enlyze.com/enlyze/drone-sops-gke
+
+tox_parallel_environment: &tox_parallel_environment
+  environment:
+    TOX_PARALLEL_NO_SPINNER: 1
+
+deployment_environment: &deployment_environment
+  environment:
+    GOOGLE_APPLICATION_CREDENTIALS_JSON:
+      from_secret: gke_token
+
+common_deployment_settings: &common_deployment_settings
+  zone: europe-west3-a
+  verbose: true
+  wait_deployments:
+    - customer-success-alerts
+  wait_seconds: 180
+
+webhook_common_settings: &webhook_common_settings
+  urls:
+    from_secret: mattermost_platform_team_webhook_url
+    content_type: application/json
+
+webhook_plugin_image: &webhook_plugin_image
+  image: plugins/webhook
+
+kind: pipeline
+name: CI Customer Service Alerts
+
+trigger:
+  branch:
+    - master
+
+steps:
+- name: Sparkd alert rules
+  pull: always
+  image: docker.enlyze.com/enlyze/deploy-alert-rules
+  environment:
+    DEPLOY_SSH_KEY:
+      from_secret: deploy_alert_rules_ssh_key
+    RELOAD_PASSWORD:
+      from_secret: deploy_alert_rules_prometheus_password
+  commands:
+    - >
+      deploy-alert-rules
+      --ssh-key="$${DEPLOY_SSH_KEY}"
+      --prometheus-reload-password="$${RELOAD_PASSWORD}"
+      customer-success-alerts
+      alerts.yml


### PR DESCRIPTION
**What this PR does**
**drone.yml:** 
Create pipeline for alert deployment (mainly copied from `[alerts.yml](https://github.com/enlyze/timeseries-service/blob/ec62c8ec70ea19fc2ba3d5878427eaf4620ab274/.drone.yml#L268-L285)`
**alerts.yml:** 
Add alert for cache miss rate greater than zero for more than two days.
This basically checks if subquerying rate(sparkd_bridge_datasource_cache_misses [3m])==0 over two days returns a value other than None or if it is empty.
**Questions**
Is there an easier way to check for null values? I tried absent_over_time() but it made me loose label information when testing the query in Grafana.